### PR TITLE
V0.14.4.prerelease.grok

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -250,8 +250,14 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                 data = {"error": sanitize(e.args[0]) if getattr(e, 'args') else ''}
                 return self.error_response(request, data, response_class=http.HttpBadRequest)
             except ValidationError as e:
-                data = {"error": sanitize(e.messages)}
-                return self.error_response(request, data, response_class=http.HttpBadRequest)
+                if hasattr(e, 'error_dict'):
+                    error_dict = e.message_dict
+                else:
+                    error_dict = e.update_error_dict({})
+                errors = {self._meta.resource_name: error_dict}
+                desired_format = self.determine_format(request)
+                content = self.serialize(request, errors, desired_format)
+                return http.HttpBadRequest(content, content_type=build_content_type(desired_format))
             except Exception as e:
                 # Prevent muting non-django's exceptions
                 # i.e. RequestException from 'requests' library
@@ -495,6 +501,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
         # All clear. Process the request.
         request = convert_post_to_put(request)
+        self.log_throttled_access(request)
         response = method(request, **kwargs)
 
         # Add the throttled request.

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -205,7 +205,6 @@ class Serializer(object):
 
         Default is ``iso-8601``, which looks like "2010-12-16T03:02:14".
         """
-        data = make_naive(data)
         if self.datetime_formatting == 'rfc-2822':
             return format_datetime(data)
         if self.datetime_formatting == 'iso-8601-strict':

--- a/tastypie/validation.py
+++ b/tastypie/validation.py
@@ -70,10 +70,14 @@ class FormValidation(Validation):
             # to *not* use the data in the bundle, since it is a URI to a
             # resource.  Instead, use the output of model_to_dict for
             # validation, since that is already properly hydrated.
-            for field in bundle.obj._meta.fields:
-                if field.name in bundle.data:
-                    if not isinstance(field, RelatedField):
-                        kwargs['data'][field.name] = bundle.data[field.name]
+            fields_by_name = {field.name: field for field in bundle.obj._meta.fields}
+            for field_name in bundle.data:
+                if field_name in fields_by_name:
+                    if not isinstance(fields_by_name[field_name], RelatedField):
+                        kwargs['data'][field_name] = bundle.data[field_name]
+                else:
+                    kwargs['data'][field_name] = bundle.data[field_name]
+
         else:
             kwargs['data'].update(data)
         return kwargs


### PR DESCRIPTION
[ENG-47]

**What**

Remove redundant call to _log_throttled_access_.

**Why**

The current double-call to _log_throttled_access_ results in halving of the number of password reset request accesses allowed per minute.

**How**

Remove the 2nd call to _log_throttled_access_ in _resources.py_

[ENG-47]: https://grokacademy.atlassian.net/browse/ENG-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ